### PR TITLE
Pin python to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,14 @@ RUN apt-get upgrade -y
 RUN apt-get install -y apt-utils
 # RUN apt-get install -y jupyter jupyter-core jupyter-notebook
 # RUN apt-get -y install vim python3.6 python3.6-dev python3-pip wget git apt-transport-https software-properties-common zip unzip libpaper-utils xdg-utils liblas3 libcairo2 libcurl4 libjpeg8 liblapack3 libpango-1.0-0 libpangocairo-1.0-0 libpng16-16 libtiff5 libtk8.6 libxt6 gfortran libblas-dev libatlas-base-dev liblapack-dev libatlas-base-dev libncurses5-dev libreadline-dev libjpeg-dev libpcre3-dev libpng-dev zlib1g-dev libbz2-dev liblzma-dev libicu-dev pkg-config r-base-core r-base-dev jupyter jupyter-core jupyter-notebook
-RUN apt-get install -y git python3 python3-pip wget
+RUN apt-get install -y git python3.8 python3-pip wget
 ENV PATH $PATH:/usr/local/conda/bin
 
 ## Download and install required Linux packages
 RUN apt-get -qq update && apt-get -qq -y install gnupg curl wget bzip2 git gcc vim unixodbc-dev python3-dev g++ postgresql-client r-base r-base-core r-base-dev sqlite \
 	&& wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
 	&& bash Miniconda3-latest-Linux-x86_64.sh -bfp /usr/local/conda \
-	&& conda install -y python=3 \
+	&& conda install -y python=3.8 \
 	&& conda update conda \
 	&& apt-get -qq -y autoremove \
 	&& apt-get autoclean \


### PR DESCRIPTION
`azureml-core`, which is part of `mlflow[extras]`, is incompatible with Python 3.9: https://github.com/Azure/MachineLearningNotebooks/issues/1285

The alternative would be to not use `mlflow[extras]` and only separately install the pieces we definitely need, but pinning to python 3.8 is easy.